### PR TITLE
修复模态框无法关闭的bug

### DIFF
--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -34,18 +34,12 @@
 
     mask.show();
     dialog.show();
-    mask.addClass("weui_mask_visible");
-    dialog.addClass("weui_dialog_visible");
   };
 
   $.closeModal = function() {
-    $(".weui_mask_visible").removeClass("weui_mask_visible").transitionEnd(function() {
-      $(this).remove();
-    });
-    $(".weui_dialog_visible").removeClass("weui_dialog_visible").transitionEnd(function() {
-      $(this).remove();
-    });
-  };
+    $(".weui_mask_visible").remove();
+    $(".weui_dialog_visible").remove();
+   };
 
   $.alert = function(text, title, callback) {
     if (typeof title === 'function') {

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -37,8 +37,8 @@
   };
 
   $.closeModal = function() {
-    $(".weui_mask_visible").remove();
-    $(".weui_dialog_visible").remove();
+    $(".weui_mask").remove();
+    $(".weui_dialog").remove();
    };
 
   $.alert = function(text, title, callback) {


### PR DESCRIPTION
引用原生的weui css 无法关闭模态框。 