### PR TITLE
fix bug: Calendar未支持文档中写的closeByOutsideClick属性

### DIFF
--- a/src/js/calendar.js
+++ b/src/js/calendar.js
@@ -678,7 +678,7 @@
       }
       
       //iphone 上无法正确触发 click，会导致点击外面无法关闭
-      if (!p.inline) $(document).on('click touchend', closeOnHTMLClick);
+      if (!p.inline && p.params.closeByOutsideClick) $(document).on('click touchend', closeOnHTMLClick);
 
       // Open
       function onPickerClose() {
@@ -827,6 +827,7 @@
     touchMove: true,
     animate: true,
     closeOnSelect: true,
+    closeByOutsideClick: true,
     monthPicker: true,
     monthPickerTemplate: 
         '<div class="picker-calendar-month-picker">' +


### PR DESCRIPTION
官网文档中关于calendar的参数说明中有
closeByOutsideClick	boolean	true	点击日历外面关闭
代码中未实现，补充实现。