### PR TITLE
fix 下拉刷新，当容器不是body时的bug

### DIFF
--- a/src/js/pull-to-refresh.js
+++ b/src/js/pull-to-refresh.js
@@ -7,6 +7,7 @@
   "use strict";
 
   var PTR = function(el) {
+    this.body = $('body');
     this.container = $(el);
     this.distance = 50;
     this.attachEvents();
@@ -22,7 +23,7 @@
   PTR.prototype.touchMove= function(e) {
     if(this.container.hasClass("refreshing")) return;
     if(!this.start) return false;
-    if(this.container.scrollTop() > 0) return;
+    if(this.container.scrollTop() > 0 || this.body.scrollTop() > 0) return;
     var p = $.getTouchPosition(e);
     this.diffX = p.x - this.start.x;
     this.diffY = p.y - this.start.y;


### PR DESCRIPTION
背景：下拉刷新的容器为界面中某个 div，且 div 高度超过1屏
BUG：界面滚动到一半后，想滑动 div 回到顶部，这时会触发下拉刷新，且界面无法回到顶部
修复：添加 $('body').scrollTop() 的判断

  var PTR = function(el) {
    **_this.body = $('body');_**
    this.container = $(el);
    this.distance = 50;
    this.attachEvents();
  }

  PTR.prototype.touchMove= function(e) {
    if(this.container.hasClass("refreshing")) return;
    if(!this.start) return false;
    if(this.container.scrollTop() > 0 **_|| this.body.scrollTop() > 0_**) return;
