### PR TITLE
修复ios版微信下 加载提示闪烁

### DIFF
--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -10,8 +10,8 @@
     var tpl = '<div class="weui-toast ' + className + '">' + html + '</div>';
     var dialog = $(tpl).appendTo(document.body);
 
-    dialog.show();
     dialog.addClass("weui-toast--visible");
+    dialog.show();
   };
 
   var hide = function(callback) {


### PR DESCRIPTION
在ios版微信下，“数据加载中”提示会出现重复并移位。是一闪而过的动态。