### PR TITLE
修复popup 极快速点击多次以后假死

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -30,9 +30,9 @@
     container.find('.weui-popup__modal').transitionEnd(function() {
       var $this = $(this);
       $this.trigger("close");
-      container.hide();
       remove && container.remove();
-    })
+    });
+    container.hide();
     container.removeClass("weui-popup__container--visible")
   };
 


### PR DESCRIPTION
修复popup 极快速点击多次以后 弹出层没有，但是笼罩层一直存在，无法在点击界面上的其他元素